### PR TITLE
Send a list of users instead of the username of the user who most recently joined or left

### DIFF
--- a/server/__main__.py
+++ b/server/__main__.py
@@ -6,7 +6,6 @@ import websockets
 CONNECTIONS = {}
 USER_COUNT = len(CONNECTIONS)
 USER_LIMIT = int()
-LAST_USER = str()
 
 
 async def request_uname(ws):
@@ -60,15 +59,17 @@ async def send_user_count_event():
     while True:
         if USER_COUNT < len(CONNECTIONS):
             USER_COUNT = len(CONNECTIONS)
+            ulist = str(list(CONNECTIONS.keys())).replace("'", '"')
             websockets.broadcast(
                 CONNECTIONS.values(),
-                f'{{"event": "user_join", "count": {USER_COUNT}, "uname": "{list(CONNECTIONS.keys())[-1]}"}}',
+                f'{{"event": "user_join", "count": {USER_COUNT}, "uname_list": {ulist}}}',
             )
         elif USER_COUNT > len(CONNECTIONS):
             USER_COUNT = len(CONNECTIONS)
+            ulist = str(list(CONNECTIONS.keys())).replace("'", '"')
             websockets.broadcast(
                 CONNECTIONS.values(),
-                f'{{"event": "user_leave", "count": {USER_COUNT}, "uname": "{LAST_USER}"}}',
+                f'{{"event": "user_leave", "count": {USER_COUNT}, "uname_list": {ulist}}}',
             )
         await asyncio.sleep(1)
 


### PR DESCRIPTION
Send a list of users in `user_join` and `user_leave` events instead of the username of the user that joins or leaves so that all users have a full list of all other users.